### PR TITLE
Fix document.activeElement-related test failures

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.test.tsx
@@ -44,9 +44,10 @@ describe("Steps settings component", () => {
     // Other Advanced settings details tested in advanced-settings.test.tsx
 
     // Change form content
+    getByPlaceholderText("Please enter target permissions").focus();
     fireEvent.change(getByPlaceholderText("Please enter target permissions"), {target: {value: "data-hub-common,read"}});
     expect(getByPlaceholderText("Please enter target permissions")).toHaveValue("data-hub-common,read");
-    fireEvent.blur(getByPlaceholderText("Please enter target permissions"));
+    getByPlaceholderText("Please enter target permissions").blur();
 
     // Switch to Basic tab and cancel
     await wait(() => {
@@ -118,9 +119,10 @@ describe("Steps settings component", () => {
     wait(() => expect(screen.getByText(ErrorTooltips.disabledTab)).toBeInTheDocument());
 
     // Fix error, verify other tab enabled
+    getByPlaceholderText("Please enter target permissions").focus();
     fireEvent.change(getByPlaceholderText("Please enter target permissions"), {target: {value: "data-hub-common,read"}});
     expect(getByPlaceholderText("Please enter target permissions")).toHaveValue("data-hub-common,read");
-    fireEvent.blur(getByPlaceholderText("Please enter target permissions"));
+    getByPlaceholderText("Please enter target permissions").blur();
     expect(getByTestId("validationError")).toHaveTextContent("");
 
     expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-disabled");
@@ -190,8 +192,10 @@ describe("Steps settings component", () => {
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");
     expect(nameField).toBeInTheDocument();
+    nameField.focus();
     fireEvent.change(nameField, {target: {value: testName}});
     expect(nameField).toHaveValue(testName);
+    nameField.blur();
 
     // Switch to enabled Advanced tab, check default collections
     await wait(() => {
@@ -237,8 +241,10 @@ describe("Steps settings component", () => {
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");
     expect(nameField).toBeInTheDocument();
+    nameField.focus();
     fireEvent.change(nameField, {target: {value: testName}});
     expect(nameField).toHaveValue(testName);
+    nameField.blur();
 
     // Enter required source collection
     const collInput = document.querySelector(("#collList .ant-input"))!;
@@ -290,8 +296,10 @@ describe("Steps settings component", () => {
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");
     expect(nameField).toBeInTheDocument();
+    nameField.focus();
     fireEvent.change(nameField, {target: {value: testName}});
     expect(nameField).toHaveValue(testName);
+    nameField.blur();
 
     // Enter required source collection
     const collInput = document.querySelector(("#collList .ant-input"))!;
@@ -337,8 +345,10 @@ describe("Steps settings component", () => {
     // Enter required name
     const nameField = getByPlaceholderText("Enter name");
     expect(nameField).toBeInTheDocument();
+    nameField.focus();
     fireEvent.change(nameField, {target: {value: testName}});
     expect(nameField).toHaveValue(testName);
+    nameField.blur();
 
     // Enter required source collection
     const collInput = document.querySelector(("#collList .ant-input"))!;

--- a/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
+++ b/marklogic-data-hub-central/ui/src/pages/Load.test.tsx
@@ -28,7 +28,7 @@ describe("Load component", () => {
     const authorityService = new AuthoritiesService();
     authorityService.setAuthorities(["readIngestion"]);
 
-    const {debug, baseElement, getByText, getByPlaceholderText, getByLabelText, getByTestId, queryByTestId, queryByTitle} = render(
+    const {baseElement, getByText, getByPlaceholderText, getByLabelText, getByTestId, queryByTestId, queryByTitle} = render(
       <MemoryRouter><AuthoritiesContext.Provider value={authorityService}><Load/></AuthoritiesContext.Provider></MemoryRouter>
     );
 
@@ -63,7 +63,7 @@ describe("Load component", () => {
     });
     expect(getByText("Basic").closest("div")).not.toHaveClass("ant-tabs-tab-active");
     expect(getByText("Advanced").closest("div")).toHaveClass("ant-tabs-tab-active");
-    debug();
+
     expect(await(waitForElement(() => getByText("Target Database")))).toBeInTheDocument();
     expect(getByLabelText("headers-textarea")).toBeDisabled();
     fireEvent.click(getByText("Processors"));
@@ -154,8 +154,10 @@ describe("Load component", () => {
     expect(queryAllByText("Invalid JSON").length === 2);
     fireEvent.change(getByLabelText("processors-textarea"), {target: {value: "{\"goodJSON\": true}"}});
     expect(queryAllByText("Invalid JSON").length === 1);
+    getByLabelText("customHook-textarea").focus();
     fireEvent.change(getByLabelText("customHook-textarea"), {target: {value: "{\"goodJSON\": true}"}});
     expect(queryAllByText("Invalid JSON").length === 0);
+    getByLabelText("customHook-textarea").blur();
 
     expect(getByTestId("testLoad-save-settings")).not.toBeDisabled();
     fireEvent.click(getByTestId("testLoad-cancel-settings"));


### PR DESCRIPTION
Wrap form element interactions with focus and blur to trigger the required payload-saving useEffect.